### PR TITLE
Fix Composer package to be properly marked as a WordPress plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,16 @@
 {
   "name": "filter-agency/filter-ai",
   "description": "Powerful AI content creation tools integrated directly into the WordPress editor for effortless content generation.",
+  "type": "wordpress-plugin",
   "license": "GPL-3.0",
   "require": {
     "php": ">=7.4",
+    "composer/installers": "~1.0",
     "woocommerce/action-scheduler": "^3.9"
   },
   "config": {
     "allow-plugins": {
+      "composer/installers": true,
       "dealerdirect/phpcodesniffer-composer-installer": true
     }
   },


### PR DESCRIPTION
The [Composer/Packagist version of this plugin](https://packagist.org/packages/filter-agency/filter-ai) is not properly configured as a WordPress plugin.

For WordPress installations managed via Composer this means it would not be installed in the proper `wp-content/plugins` folder, but in the Composer-default `vendor` directory for regular packages.

This PR fixes this by configuring this as a WordPress plugin and setting up the required `composer/installers` dependency that is needed for this kind of override.