### PR TITLE
Generate image fixes

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -27,6 +27,7 @@ function filter_ai_get_default_settings() {
 		'dynamic_add_alt_text_enabled'       => true,
 
 		'generate_image_pre_prompt'          => esc_html__( 'Please generate an image that is optimised for web use and is based on the following prompt:', 'filter-ai' ),
+		'generate_image_enabled'             => true,
 
 		'post_title_enabled'                 => true,
 		'post_title_prompt'                  => esc_html__( 'Please generate an SEO-friendly title for this page that is between 40 and 60 characters based on the following content:', 'filter-ai' ),

--- a/src/mediaLibrary/mainMediaLibrary/button.tsx
+++ b/src/mediaLibrary/mainMediaLibrary/button.tsx
@@ -2,16 +2,23 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Modal } from '@wordpress/components';
 import GenerateImgTabView from '@/mediaLibrary/tabs/generateImageTab/generateImgTabView';
+import { useSettings } from '@/settings';
 
 const GenerateImageButtonUI = () => {
   const [isOpen, setIsOpen] = useState(false);
 
+  const { settings } = useSettings();
+
   const openModal = () => setIsOpen(true);
   const closeModal = () => setIsOpen(false);
 
+  if (!settings?.generate_image_enabled) {
+    return null;
+  }
+
   return (
     <>
-      <Button variant="secondary" onClick={openModal} className="filter-ai-media-lib-generate-btn">
+      <Button onClick={openModal} className="filter-ai-media-lib-generate-btn page-title-action">
         {__('Generate AI Image', 'filter-ai')}
       </Button>
 

--- a/src/mediaLibrary/tabs/generateImageTab/generateImgTabView.tsx
+++ b/src/mediaLibrary/tabs/generateImageTab/generateImgTabView.tsx
@@ -5,6 +5,7 @@ import { Button, Notice, TextareaControl, __experimentalGrid as Grid } from '@wo
 import { hideLoadingMessage, showLoadingMessage, showNotice } from '@/utils';
 import { getService } from '@/utils/ai/services/getService';
 import { createInterpolateElement, useState, useEffect } from '@wordpress/element';
+import { useSettings } from '@/settings';
 
 const GenerateImgTabView = () => {
   const [prompt, setPrompt] = useState('');
@@ -13,6 +14,8 @@ const GenerateImgTabView = () => {
   const [loading, setLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [isServiceConfigured, setIsServiceConfigured] = useState<boolean>(true);
+
+  const { settings } = useSettings();
 
   const handleGenerate = async () => {
     setLoading(true);
@@ -102,19 +105,11 @@ const GenerateImgTabView = () => {
         });
       }
     })();
-
-    const toolbar = document.querySelector('.media-toolbar') as HTMLDivElement;
-
-    if (toolbar) {
-      toolbar.style.display = 'none';
-    }
-
-    return () => {
-      if (toolbar) {
-        toolbar.style.display = '';
-      }
-    };
   }, []);
+
+  if (!settings?.generate_image_enabled) {
+    return null;
+  }
 
   return (
     <>
@@ -141,7 +136,7 @@ const GenerateImgTabView = () => {
       </p>
       <p>
         {__(
-          'Once images are generated, choose one or more of those to import into your Media Library, and then choose one image to insert.',
+          'Once your images are generated, you can choose one or more of those to import into your Media Library.',
           'filter-ai'
         )}
       </p>
@@ -159,7 +154,7 @@ const GenerateImgTabView = () => {
           variant="secondary"
           onClick={handleGenerate}
           className="filter-ai-generate-button"
-          disabled={loading || !isServiceConfigured}
+          disabled={loading || !isServiceConfigured || !prompt}
         >
           {loading ? __('Generating...', 'filter-ai') : __('Generate Images', 'filter-ai')}
         </Button>

--- a/src/settings/sections.ts
+++ b/src/settings/sections.ts
@@ -100,12 +100,20 @@ export const sections: Section[] = [
         key: 'dynamic_add_alt_text',
         toggle: {
           key: 'dynamic_add_alt_text_enabled',
-          label: __('Dynamically add missing image alt text in existing posts', 'filter-ai'),
+          label: __('Dynamically add missing alt text', 'filter-ai'),
           help: __(
             `Core WordPress doesn't update the alt text in existing content by default when updated via the media library.`,
             'filter-ai'
           ),
           dependency: 'image_alt_text_enabled',
+        },
+      },
+      {
+        key: 'generate_image',
+        toggle: {
+          key: 'generate_image_enabled',
+          label: __('Generate images', 'filter-ai'),
+          help: __('Generate images within the Media Library.', 'filter-ai'),
         },
       },
     ],

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -168,7 +168,7 @@ const Settings = () => {
                 </h2>
               </PanelHeader>
               {section.features.map((feature) => (
-                <PanelBody>
+                <PanelBody className={feature?.toggle?.dependency ? 'has-dependency' : ''}>
                   <PanelRow className="filter-ai-settings-field">
                     <div className="filter-ai-settings-field-text">
                       <label htmlFor={feature.toggle.key}>{feature.toggle.label}</label>

--- a/src/styles/generateAiImg.css
+++ b/src/styles/generateAiImg.css
@@ -86,6 +86,10 @@
   color: #0a4b78;
 }
 
+.filter-ai-media-lib-generate-btn.page-title-action {
+  top: 0 !important;
+}
+
 .filter-ai-generator-modal {
   padding-bottom: 15px;
   overflow-y: auto;

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -141,6 +141,10 @@
     font-size: 15px;
   }
 
+  & .components-panel__body.has-dependency {
+    border-top-color: #fff;
+  }
+
   & .components-panel__body p {
     &:first-child {
       margin-top: 0;


### PR DESCRIPTION
- Add setting to control whether to show or hide image generation. 
- Fix generate AI image button styling.
- Fix how we hide the media toolbar within the media library modal. 
- Update content.
- Refactor how the generate image tab is added to the modal to reduce number of renders. 
- Add code to change the default selected media library modal tab after feature is turned off so the user isn't shown a blank modal.
- Tweak styling of dependent settings so they are grouped together.

https://app.asana.com/1/155579732034488/project/1208724073347094/task/1210397645269618?focus=true