### PR TITLE
image generation fixes

### DIFF
--- a/src/mediaLibrary/mainMediaLibrary/button.tsx
+++ b/src/mediaLibrary/mainMediaLibrary/button.tsx
@@ -29,7 +29,7 @@ const GenerateImageButtonUI = () => {
           shouldCloseOnClickOutside={true}
           className="filter-ai-generator-modal"
         >
-          <GenerateImgTabView />
+          <GenerateImgTabView callback={closeModal} />
         </Modal>
       )}
     </>

--- a/src/mediaLibrary/tabs/generateImageTab/index.tsx
+++ b/src/mediaLibrary/tabs/generateImageTab/index.tsx
@@ -73,13 +73,15 @@ declare const wp: any;
       const container = document.createElement('div');
       container.className = 'generateImg-content';
 
+      const callback = () => this.content.mode('browse');
+
       const View = wp.Backbone.View.extend({
         className: 'generateImg-wrapper',
         render: function () {
           this.$el.append(container);
 
           try {
-            renderGenerateImgReact(container);
+            renderGenerateImgReact(container, callback);
 
             if (!isToolbarHidden) {
               parent.addClass('hide-toolbar');
@@ -109,9 +111,9 @@ declare const wp: any;
 
 let root: any = null;
 
-function renderGenerateImgReact(container: HTMLElement) {
+function renderGenerateImgReact(container: HTMLElement, callback: () => void) {
   root = createRoot(container);
-  root.render(<GenerateImgTabView />);
+  root.render(<GenerateImgTabView callback={callback} />);
 }
 
 function unmountGenerateImgReact() {

--- a/src/styles/generateAiImg.css
+++ b/src/styles/generateAiImg.css
@@ -19,7 +19,7 @@
   margin-top: 5px;
 }
 
-.filter-ai-upload-button {
+.filter-ai-import-button {
   margin-top: 15px;
 }
 
@@ -73,9 +73,14 @@
 
 .filter-ai-button-container {
   display: inline-block;
-  vertical-align: middle;
   margin-left: 8px;
-  margin-top: -9px;
+  position: relative;
+  top: -3px;
+
+  & button {
+    margin-left: 0;
+    height: auto;
+  }
 }
 
 .filter-ai-media-lib-generate-btn {
@@ -110,8 +115,6 @@
 }
 
 .components-modal__frame.filter-ai-generator-modal {
-  width: 60vw;
-  max-width: 900px;
-  height: auto;
-  max-height: 90vh;
+  width: 100%;
+  max-width: 46.875rem;
 }

--- a/src/utils/ai/uploadGeneratedImage.ts
+++ b/src/utils/ai/uploadGeneratedImage.ts
@@ -21,7 +21,7 @@ export const refreshMediaLibrary = () => {
   }, 500);
 };
 
-export const uploadGeneratedImageToMediaLibrary = async (dataUrl: string, filename: string, promptText?: string) => {
+export const uploadGeneratedImageToMediaLibrary = async (dataUrl: string, filename: string) => {
   return new Promise(async (resolve, reject) => {
     const { helpers } = window.aiServices.ai;
 
@@ -37,25 +37,14 @@ export const uploadGeneratedImageToMediaLibrary = async (dataUrl: string, filena
       lastModified: new Date().getTime(),
     });
 
-    const attachmentData: {
-      caption?: {
-        rendered: string;
-        raw?: string;
-      };
-    } = {};
-
-    if (promptText) {
-      const captionString = sprintf(__('Generated for prompt: %s', 'filter-ai'), promptText);
-
-      attachmentData.caption = {
-        rendered: captionString,
-        raw: captionString,
-      };
-    }
-
     uploadMedia({
       filesList: [file],
-      additionalData: attachmentData,
+      additionalData: {
+        title: {
+          raw: __('Filter AI generated image', 'filter-ai'),
+          rendered: __('Filter AI generated image', 'filter-ai'),
+        },
+      },
       onFileChange: ([attachment]) => {
         if (!attachment) {
           reject(__('Saving file failed.', 'filter-ai'));

--- a/src/utils/loadingMessage/container.tsx
+++ b/src/utils/loadingMessage/container.tsx
@@ -13,8 +13,8 @@ const LoadingMessage = () => {
         return __('Customising %s', 'filter-ai');
       case 'summarising':
         return __('Summarising %s', 'filter-ai');
-      case 'uploading':
-        return __('Uploading %s', 'filter-ai');
+      case 'importing':
+        return __('Importing %s', 'filter-ai');
       default:
         return __('Generating %s', 'filter-ai');
     }
@@ -43,8 +43,8 @@ const LoadingMessage = () => {
       <div className="filter-ai-loading-message">
         <h2>{sprintf(title, label)}</h2>
         <p>
-          {type === 'uploading'
-            ? sprintf(__('Uploading and processing your %s...', 'filter-ai'), convertToLowerCase(label))
+          {type === 'importing'
+            ? sprintf(__('Importing and processing your %s...', 'filter-ai'), convertToLowerCase(label))
             : sprintf(
                 __('Analysing your requirements and crafting the perfect %s.', 'filter-ai'),
                 convertToLowerCase(label)

--- a/src/utils/loadingMessage/store.ts
+++ b/src/utils/loadingMessage/store.ts
@@ -4,7 +4,7 @@ const storeName = 'filter-ai/loading-message-store';
 
 type State = {
   label: string;
-  type: 'generating' | 'summarising' | 'customising' | 'uploading';
+  type: 'generating' | 'summarising' | 'customising' | 'importing';
 };
 
 type Action = {


### PR DESCRIPTION
* changed "image" text to "images" within the generating modal
* when generating or importing and the blue modal is shown we now hide the generate image modal that is shown from the media library page
* changed instances of "upload" and "uploading" to "import" and "importing"
* removed caption from generated images
* changed image filename to `filter-ai-image-{index}`
* changed image title to "Filter AI generated image"
* once the image has been imported the modal will either be closed if on the media library page or the user taken to the media library tab if within the modal

https://app.asana.com/1/155579732034488/project/1210410357063630/task/1210397645269618?focus=true