### PR TITLE
Update messaging across settings and generation pages

### DIFF
--- a/filter-ai.php
+++ b/filter-ai.php
@@ -58,8 +58,6 @@ function filter_ai_options_page() {
 		return;
 	}
 
-	wp_admin_notice( 'test' );
-
 	?>
 	<div class="wrap" style="display:none;"><h2></h2></div>
 	<div class="filter-wrap" id="filter-ai-settings-container"></div>

--- a/filter-ai.php
+++ b/filter-ai.php
@@ -51,36 +51,24 @@ add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'filter_ai_add
 
 /**
  *  Add settings page
+ *  Contains a hidden div.wrap to hide admin notices
  */
 function filter_ai_options_page() {
 	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
 	}
 
-	try {
-		ai_services()->get_available_service();
-	} catch ( InvalidArgumentException $e ) {
-		add_settings_error(
-			'filter_ai_messages',
-			'filter_ai_message_missing_plugin',
-			sprintf(
-			/* translators: 1: %s expands to a website link to AI Services settings, 2: </a> closing tag. */
-				esc_html__( 'Please activate an AI within the %1$sAI Services%2$s plugin.', 'filter-ai' ),
-				'<a href="options-general.php?page=ais_services">',
-				'</a>'
-			),
-			'warning'
-		);
-	}
+	wp_admin_notice( 'test' );
 
-	settings_errors( 'filter_ai_messages' );
 	?>
-	<div class="wrap" id="filter-ai-settings-container"></div>
+	<div class="wrap" style="display:none;"><h2></h2></div>
+	<div class="filter-wrap" id="filter-ai-settings-container"></div>
 	<?php
 }
 
 /**
  *  Add batch page
+ *  Contains a hidden div.wrap to hide admin notices
  */
 function filter_ai_batch_page() {
 	if ( ! current_user_can( 'manage_options' ) ) {
@@ -88,7 +76,8 @@ function filter_ai_batch_page() {
 	}
 
 	?>
-	<div class="wrap" id="filter-ai-batch-container"></div>
+	<div class="wrap" style="display:none;"><h2></h2></div>
+	<div class="filter-wrap" id="filter-ai-batch-container"></div>
 	<?php
 }
 

--- a/src/components/aiServiceNotice/index.tsx
+++ b/src/components/aiServiceNotice/index.tsx
@@ -1,0 +1,27 @@
+import { Notice } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+
+export default function AIServiceNotice() {
+  // @ts-expect-error Type 'never' has no call signatures.
+  const AIService = useSelect((select) => select(window.aiServices.ai.store)?.getAvailableService(), []);
+
+  if (AIService === null) {
+    return (
+      <Notice status="error" isDismissible={false}>
+        {createInterpolateElement(
+          sprintf(
+            __(`No AI service is configured. Please add an API key in the %s plugin settings.`, 'filter-ai'),
+            `<a>AI Services</a>`
+          ),
+          {
+            a: <a href="/wp-admin/options-general.php?page=ais_services" />,
+          }
+        )}
+      </Notice>
+    );
+  }
+
+  return null;
+}

--- a/src/settings/batchGeneration/imageAltText.tsx
+++ b/src/settings/batchGeneration/imageAltText.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import { Button, Spinner, Panel, PanelBody, ProgressBar } from '@wordpress/components';
-import { useEffect, useCallback, useState } from '@wordpress/element';
+import { Button, Spinner, Panel, PanelBody, ProgressBar, Notice } from '@wordpress/components';
+import { useEffect, useCallback, useState, RawHTML } from '@wordpress/element';
 import { mimeTypes } from '@/utils';
 import { useSettings } from '../useSettings';
 import { __, sprintf } from '@wordpress/i18n';
@@ -118,6 +118,18 @@ const ImageAltText = () => {
 
   return (
     <>
+      {!!settings && !settings.image_alt_text_enabled && (
+        <Notice status="error" isDismissible={false}>
+          <RawHTML>
+            {sprintf(
+              __('Please activate this feature in the %1$sSettings%2$s.', 'filter-ai'),
+              '<a href="/wp-admin/admin.php?page=filter_ai">',
+              '</a>'
+            )}
+          </RawHTML>
+        </Notice>
+      )}
+
       {isLoading && <Spinner className="filter-ai-settings-spinner" />}
 
       {!isLoading && (

--- a/src/settings/batchGeneration/index.tsx
+++ b/src/settings/batchGeneration/index.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import ImageAltText from './imageAltText';
 import SEOTitles from './seoTitles';
 import SEOMetaDescriptions from './seoMetaDescriptions';
+import AIServiceNotice from '@/components/aiServiceNotice';
 
 type Tab = {
   label: string;
@@ -85,6 +86,7 @@ const BatchGeneration = () => {
         </nav>
       </header>
       <div className="filter-ai-settings-content">
+        <AIServiceNotice />
         <Content />
         <div>
           <a href="/wp-admin/tools.php?page=action-scheduler">{__('View batch generation log', 'filter-ai')}</a>

--- a/src/settings/batchGeneration/seoMetaDescriptions.tsx
+++ b/src/settings/batchGeneration/seoMetaDescriptions.tsx
@@ -1,5 +1,5 @@
-import { Button, Spinner, Panel, PanelBody, ProgressBar } from '@wordpress/components';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { Button, Spinner, Panel, PanelBody, ProgressBar, Notice } from '@wordpress/components';
+import { RawHTML, useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSettings } from '../useSettings';
 
@@ -126,6 +126,24 @@ const SEOMetaDescriptions = () => {
 
   return (
     <>
+      {!window.filter_ai_dependencies.yoast_seo && (
+        <Notice status="error" isDismissible={false}>
+          {__('Please install and activate the Yoast SEO plugin.', 'filter-ai')}
+        </Notice>
+      )}
+
+      {!!settings && !settings.yoast_seo_meta_description_enabled && (
+        <Notice status="error" isDismissible={false}>
+          <RawHTML>
+            {sprintf(
+              __('Please activate this feature in the %1$sSettings%2$s.', 'filter-ai'),
+              '<a href="/wp-admin/admin.php?page=filter_ai">',
+              '</a>'
+            )}
+          </RawHTML>
+        </Notice>
+      )}
+
       {isLoading && <Spinner className="filter-ai-settings-spinner" />}
 
       {!isLoading && (

--- a/src/settings/batchGeneration/seoTitles.tsx
+++ b/src/settings/batchGeneration/seoTitles.tsx
@@ -1,5 +1,5 @@
-import { Button, Spinner, Panel, PanelBody, ProgressBar } from '@wordpress/components';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { Button, Spinner, Panel, PanelBody, ProgressBar, Notice } from '@wordpress/components';
+import { RawHTML, useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSettings } from '../useSettings';
 
@@ -126,6 +126,24 @@ const SEOTitles = () => {
 
   return (
     <>
+      {!window.filter_ai_dependencies.yoast_seo && (
+        <Notice status="error" isDismissible={false}>
+          {__('Please install and activate the Yoast SEO plugin.', 'filter-ai')}
+        </Notice>
+      )}
+
+      {!!settings && !settings.yoast_seo_title_enabled && (
+        <Notice status="error" isDismissible={false}>
+          <RawHTML>
+            {sprintf(
+              __('Please activate this feature in the %1$sSettings%2$s.', 'filter-ai'),
+              '<a href="/wp-admin/admin.php?page=filter_ai">',
+              '</a>'
+            )}
+          </RawHTML>
+        </Notice>
+      )}
+
       {isLoading && <Spinner className="filter-ai-settings-spinner" />}
 
       {!isLoading && (

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -16,6 +16,7 @@ import { sections } from './sections';
 import { filterLogoWhite } from '@/assets/filter-logo';
 import { verticalDots } from '@/assets/vertical-dots';
 import { __ } from '@wordpress/i18n';
+import AIServiceNotice from '@/components/aiServiceNotice';
 
 type ShowButtonProps = {
   extraKey: string;
@@ -152,6 +153,8 @@ const Settings = () => {
         </div>
       </header>
       <div className="filter-ai-settings-content">
+        <AIServiceNotice />
+
         {sections.map((section) => {
           let isDisabled = false;
 

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -202,3 +202,15 @@
     opacity: 0.5;
   }
 }
+
+.filter-wrap {
+  margin: 10px 20px 0 2px;
+}
+
+@media screen and (max-width: 782px) {
+  .filter-wrap {
+    clear: both;
+    margin-right: 12px;
+    margin-left: 0;
+  }
+}

--- a/src/utils/ai/services/getService.ts
+++ b/src/utils/ai/services/getService.ts
@@ -1,7 +1,9 @@
+import { resolveSelect } from '@wordpress/data';
+
 const { store } = window.aiServices.ai;
 
 export const getService = async (capabilities: string[] = []) => {
-  const aiService = await window.wp?.data.resolveSelect(store);
+  const aiService = await resolveSelect(store);
 
   await aiService.getServices();
 


### PR DESCRIPTION
Update messaging across settings and generation pages.

* add code to hide the admin notices so they don't break the settings and batch headers
* add new `AIServiceNotice` component so we can reuse in various places
* refactor `generateImgTabView` to use the new `AIServiceNotice`
* add extra messages to the settings and batch generation pages to explain why they are disabled
* refactor `getService` to use `@wordpress/data` rather than `window.wp.data` property

https://app.asana.com/1/155579732034488/project/1210410357063630/task/1210916279781589?focus=true