### PR TITLE
Fix _load_textdomain_just_in_time was called incorrectly

### DIFF
--- a/includes/updater.php
+++ b/includes/updater.php
@@ -41,7 +41,7 @@ if ( ! class_exists( 'filter_ai_updater' ) ) {
 		 */
 		public function __construct() {
 			$this->plugin_slug   = 'filter-ai';
-			$this->version       = get_plugin_data( FILTER_AI_PATH . '/filter-ai.php' )['Version'];
+			$this->version       = get_plugin_data( FILTER_AI_PATH . '/filter-ai.php', false, false )['Version'];
 			$this->cache_key     = 'filter_ai_updater_cache';
 			$this->cache_allowed = true;
 


### PR DESCRIPTION
Update get_plugin_data to tell it not to load translations as we are using it before the init.

https://app.asana.com/1/155579732034488/project/1210410357063630/task/1211005455142561?focus=true