### PR TITLE
Guy Classic Editor Fixes

### DIFF
--- a/src/postToolbar/useGenerateExcerpt.ts
+++ b/src/postToolbar/useGenerateExcerpt.ts
@@ -127,7 +127,6 @@ export const useGenerateExcerpt = () => {
         throw new Error(__('No content available to generate an excerpt from.', 'filter-ai'));
       }
 
-      // Convert null to undefined to satisfy the expected type
       const generatedExcerpt = await ai.getExcerptFromContent(content, oldExcerpt ?? undefined, prompt);
       if (!generatedExcerpt) {
         throw new Error(__('Sorry, there has been an issue while generating your excerpt.', 'filter-ai'));

--- a/src/postToolbar/useGenerateTitle.ts
+++ b/src/postToolbar/useGenerateTitle.ts
@@ -114,7 +114,6 @@ export const useGenerateTitle = () => {
       let oldTitle: string;
 
       if (isBlockEditor && blockEditorData.content !== null) {
-        // Correctly handle the potential null values from blockEditorData
         const data = getBlockEditorData(blockEditorData.content, blockEditorData.oldTitle || '');
         content = data.content;
         oldTitle = data.oldTitle;


### PR DESCRIPTION
Added a few changes to useGenerateExcerpt.ts and useGenerateTitle.ts so that they more robustly take into account whether a classic editor page is active or not. Previously, elements of the block editor page were still being executed, causing the following error to pop up.

<img width="496" height="243" alt="Screenshot 2025-09-15 at 11 41 01" src="https://github.com/user-attachments/assets/55ad948c-bf3c-4703-b010-18bd32eef3e1" />

Interestingly, this error only arises when directly installing the classic editor via plugin.

My code may need a bit of a tidy up but for now it's working.